### PR TITLE
LeakyIntegrator: Make sure discontinuous gradients are handled correctly in backward pass

### DIFF
--- a/sinabs/exodus/leaky.py
+++ b/sinabs/exodus/leaky.py
@@ -60,6 +60,8 @@ class LeakyIntegrator(torch.autograd.Function):
             alpha, = ctx.saved_tensors
             grad_alpha = None
 
-        grad_input = exodus_cuda.leakyBackward(grad_output, alpha)
+        grad_input = exodus_cuda.leakyBackward(
+            grad_output.contiguous(), alpha.contiguous()
+        )
 
         return grad_input, grad_alpha, None, None

--- a/sinabs/exodus/spike.py
+++ b/sinabs/exodus/spike.py
@@ -238,8 +238,8 @@ class IntegrateAndFire(torch.autograd.Function):
             surrogates.contiguous(),
             grad_output.contiguous(),
             not_clipped.contiguous(),
-            alpha,
-            alpha * membrane_subtract,
+            alpha.contiguous(),
+            alpha * membrane_subtract.contiguous(),
         )
 
         # Gradient wrt alpha
@@ -251,8 +251,8 @@ class IntegrateAndFire(torch.autograd.Function):
                 v_mem_post.contiguous(),
                 v_mem_init.contiguous(),
                 not_clipped.contiguous(),
-                alpha,
-                membrane_subtract,
+                alpha.contiguous(),
+                membrane_subtract.contiguous(),
             )
         else:
             grad_alpha = None


### PR DESCRIPTION
It can happen that `LeakyIntegrator` receives non-contiguous gradients during the backward pass. This fix makes sure that they are handled correctly.