### PR TITLE
Backpropagate through vmem

### DIFF
--- a/cuda/leaky_kernels.h
+++ b/cuda/leaky_kernels.h
@@ -115,8 +115,8 @@ __global__ void leakyBackwardKernel(
  *
  * The gradients are given by
  * \frac{d Out_t}{d \alpha} = \sum_{i=0}^{t-1} (t-i) \alpha^{t-i-1} In_i ,
- * which can be calculated recursively as
- * \frac{d Out_0}{d \alpha} = 0
+ * where In_0 is vmemInitial. The gradients can be calculated recursively as
+ * \frac{d Out_1}{d \alpha} = vmemInitial
  * \frac{d Out_{t}}{d \alpha} = \alpha * frac{d Out_{t-1}{d \alpha} + Out_{t-1}
  * because Out_{t} = \sum_{i=0}^{T} \alpha^{t-i} * In_i
  *
@@ -149,6 +149,7 @@ __global__ void leakyBackwardAlphaKernel(
 
 	// At t=0, gradient is vmemInitial
 	scalarType grad = vmemInitial[neuronID];
+	alphaGrad[neuronID] = grad * outputGrad[linearRowID];
 
 	for(unsigned t=1; t<nTimesteps; ++t){
 

--- a/cuda/lif_kernels.h
+++ b/cuda/lif_kernels.h
@@ -148,7 +148,7 @@ __global__ void lifBackwardKernel(
     float accGrad = notClipped[iIndex];
 
     // First summand of input gradient is surrogate gradient * output gradient * notClipped
-    inputGrad[iIndex] = surr[iIndex] * outputGrad[iIndex] * accGrad;
+    inputGrad[iIndex] = outputGrad[iIndex] * accGrad;
 
     float newFactor;
     unsigned jIndex;
@@ -163,7 +163,7 @@ __global__ void lifBackwardKernel(
         newFactor = alpha[neuronID] - membrSubtract[neuronID] * surr[jIndex - 1];
         accGrad *= (newFactor * notClipped[jIndex]);
         // Add new term to current gradient
-        inputGrad[iIndex] += accGrad * surr[jIndex] * outputGrad[jIndex];
+        inputGrad[iIndex] += accGrad * outputGrad[jIndex];
     }
 
 }
@@ -220,7 +220,7 @@ __global__ void lifBackwardAlphaKernel(
     float accGrad = vmemPostInitial[neuronID];
 
     // Summand of input gradient is accGrad * surrogate gradient * output gradient * notClipped
-    float newGrad = notClipped[linearRowID] * surr[linearRowID] * accGrad;
+    float newGrad = notClipped[linearRowID] * accGrad;
     alphaGrad[neuronID] = outputGrad[linearRowID] * newGrad;
 
     unsigned jIndex;
@@ -237,10 +237,11 @@ __global__ void lifBackwardAlphaKernel(
         accGrad += vmemPost[jIndex - 1];
         // Multiply with 0 if clipped
         accGrad *= notClipped[jIndex];
-        // New gradient for current time step
-        newGrad = accGrad * surr[jIndex];
-        // Add new term to current gradient scalar product
-        alphaGrad[neuronID] += newGrad * outputGrad[jIndex];
+        // // New gradient for current time step
+        // newGrad = accGrad * surr[jIndex];
+        
+	// Add new term to current gradient scalar product
+        alphaGrad[neuronID] += accGrad * outputGrad[jIndex];
     }
 
 }

--- a/sinabs/exodus/spike.py
+++ b/sinabs/exodus/spike.py
@@ -211,10 +211,10 @@ class IntegrateAndFire(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output, grad_v_mem):
 
-        if torch.nonzero(grad_v_mem).any():
-            raise NotImplementedError(
-                "Direct Backpropagation through membrane potential is currently not supported."
-            )
+        # if (grad_v_mem != 0).any():
+        #     raise NotImplementedError(
+        #         "Direct Backpropagation through membrane potential is currently not supported."
+        #     )
         
         if ctx.get_alpha_grads:
             (output_spikes, v_mem, v_mem_init, alpha, membrane_subtract) = ctx.saved_tensors
@@ -234,9 +234,10 @@ class IntegrateAndFire(torch.autograd.Function):
         # Scaling membrane_subtract with alpha compensates for different execution order
         # in forward pass (i.e. reset happens after spiking and before decay, whereas
         # backward pass assumes reset to happen after decay)
+        surrogates = surrogates.contiguous()
         grad_input = exodus_cuda.lifBackward(
-            surrogates.contiguous(),
-            grad_output.contiguous(),
+            surrogates,
+            surrogates * grad_output.contiguous() + grad_v_mem.contiguous(),
             not_clipped.contiguous(),
             alpha,
             alpha * membrane_subtract,
@@ -246,8 +247,8 @@ class IntegrateAndFire(torch.autograd.Function):
         if ctx.get_alpha_grads:
             v_mem_post = v_mem - membrane_subtract.unsqueeze(1) * output_spikes
             grad_alpha = exodus_cuda.lifBackwardAlpha(
-                surrogates.contiguous(),
-                grad_output.contiguous(),
+                surrogates,
+                surrogates * grad_output.contiguous() + grad_v_mem.contiguous(),
                 v_mem_post.contiguous(),
                 v_mem_init.contiguous(),
                 not_clipped.contiguous(),
@@ -257,4 +258,8 @@ class IntegrateAndFire(torch.autograd.Function):
         else:
             grad_alpha = None
 
-        return (grad_input, grad_alpha, None, None, None, None, None, None, None)
+        # Backpropagate one more decay step from first time point.
+        # Works because d v_1 / d inp_1 = 1 and reset on v_mem_ini is done externally.
+        grad_init = alpha * grad_input[:, 0]
+
+        return (grad_input, grad_alpha, grad_init, None, None, None, None, None, None)

--- a/tests/test_leak_functions.py
+++ b/tests/test_leak_functions.py
@@ -1,0 +1,124 @@
+import pytest
+import torch
+from sinabs.exodus.leaky import LeakyIntegrator
+from sinabs.layers.functional.lif import lif_forward
+
+
+def test_leakyintegrator():
+
+    torch.random.manual_seed(1)
+
+    inp = torch.rand((2, 10), requires_grad=True, device="cuda")
+    v_mem_initial = torch.zeros(2, device="cuda", requires_grad=True)
+
+    alpha = torch.rand_like(v_mem_initial, requires_grad=True).contiguous().cuda()
+
+    out = LeakyIntegrator.apply(
+        inp,
+        alpha,
+        v_mem_initial,
+    )
+
+    out.sum().backward()
+
+    for p in (inp, alpha, v_mem_initial):
+        assert p.grad is not None
+
+
+def test_compare_leakyintegrator_backward():
+
+    torch.manual_seed(1)
+
+    time_steps = 100
+    batchsize = 10
+    n_neurons = 8
+    num_epochs = 3
+
+    # Input data and initialization
+    input_sinabs = torch.rand(
+        (num_epochs, batchsize, time_steps, n_neurons),
+        requires_grad=True,
+        device="cuda",
+    )
+    v_mem_init_sinabs = torch.rand(
+        batchsize, n_neurons, requires_grad=True, device="cuda"
+    )
+    alpha_sinabs = torch.rand(n_neurons, requires_grad=True, device="cuda")
+
+    # Copy data without connecting gradients
+    input_exodus = input_sinabs.clone().detach().requires_grad_(True)
+    v_mem_init_exodus = v_mem_init_sinabs.clone().detach().requires_grad_(True)
+    alpha_exodus = alpha_sinabs.clone().detach().requires_grad_(True)
+
+    out_exodus = evolve_exodus(
+        data=input_exodus,
+        alpha=alpha_exodus,
+        v_mem_init=v_mem_init_exodus,
+    )
+
+    out_sinabs = evolve_sinabs(
+        data=input_sinabs,
+        alpha=alpha_sinabs,
+        v_mem_init=v_mem_init_sinabs,
+    )
+
+    assert torch.allclose(out_exodus, out_sinabs)
+
+    # random weights so the output grad tensor is less uniform
+    rand_weights = torch.rand_like(out_exodus)
+    # - Test backward pass through output spikes
+    (rand_weights * out_exodus).sum().backward()
+    (rand_weights * out_sinabs).sum().backward()
+
+    assert torch.allclose(input_sinabs.grad, input_exodus.grad)
+    assert torch.allclose(v_mem_init_sinabs.grad, v_mem_init_exodus.grad)
+    assert torch.allclose(alpha_sinabs.grad, alpha_exodus.grad)
+
+
+def evolve_exodus(
+    data: torch.tensor,
+    alpha: torch.tensor,
+    v_mem_init: torch.tensor,
+):
+    alpha = alpha.expand(v_mem_init.shape).flatten().contiguous()
+    v_mem_init = v_mem_init.flatten().contiguous()
+    batchsize, timesteps, *trailing_dim = data.shape[1:]
+
+    for inp in data:
+        inp = inp.movedim(1, -1).reshape(-1, timesteps)
+        output = LeakyIntegrator.apply(
+            inp.contiguous(),
+            alpha,
+            v_mem_init,
+        )
+
+        v_mem_init = output[:, -1].contiguous()
+
+    return output.reshape(batchsize, *trailing_dim, timesteps).movedim(-1, 1)
+
+
+def evolve_sinabs(
+    data: torch.tensor,
+    alpha: torch.tensor,
+    v_mem_init: torch.tensor,
+):
+    state = {"v_mem": v_mem_init}
+
+    for inp in data:
+        # Add batch dimension and move time to dimension 1
+
+        output, state, *__ = lif_forward(
+            input_data=inp,
+            alpha_mem=alpha,
+            alpha_syn=None,
+            state=state,
+            spike_threshold=None,
+            spike_fn=None,
+            reset_fn=None,
+            surrogate_grad_fn=None,
+            min_v_mem=None,
+            norm_input=False,
+            record_states=False,
+        )
+
+    return output

--- a/tests/test_lif.py
+++ b/tests/test_lif.py
@@ -249,6 +249,7 @@ def test_exodus_sinabs_state_transfer(train_alphas, norm_input, train_time_const
 args = product((True, False), (True, False), (True, False))
 @pytest.mark.parametrize("train_alphas,norm_input,train_time_consts", args)
 def test_exodus_vs_sinabs_compare_grads(train_alphas, norm_input, train_time_consts):
+    n_epochs = 1
     batch_size, time_steps = 10, 100
     n_input_channels, n_output_classes = 16, 10
     tau_mem = 20.0
@@ -277,12 +278,13 @@ def test_exodus_vs_sinabs_compare_grads(train_alphas, norm_input, train_time_con
         sinabs_layer.load_state_dict(exodus_layer.state_dict())
     assert (sinabs_model[0].weight == exodus_model[0].weight).all()
 
-    input_data = torch.rand((batch_size, time_steps, n_input_channels)).cuda()
+    input_data = torch.rand((n_epochs, batch_size, time_steps, n_input_channels)).cuda()
     if not norm_input:
         input_data *= 5e-2
 
     t_start = time.time()
-    sinabs_out = sinabs_model(input_data)
+    for inp_epoch in input_data:
+        sinabs_out = sinabs_model(inp_epoch)
     loss_sinabs = torch.nn.functional.mse_loss(sinabs_out, torch.ones_like(sinabs_out))
     loss_sinabs.backward()
     grads_sinabs = {
@@ -292,7 +294,8 @@ def test_exodus_vs_sinabs_compare_grads(train_alphas, norm_input, train_time_con
 
     exodus_model.zero_grad()
     t_start = time.time()
-    exodus_out = exodus_model(input_data)
+    for inp_epoch in input_data:
+        exodus_out = exodus_model(inp_epoch)
     loss_exodus = torch.nn.functional.mse_loss(exodus_out, torch.ones_like(exodus_out))
     loss_exodus.backward()
     grads_exodus = {
@@ -322,19 +325,20 @@ def test_exodus_vs_sinabs_compare_grads(train_alphas, norm_input, train_time_con
         print(k, "max difference:", max_diff, "max rel. diff.:", max_rel_diff)
         assert torch.allclose(g_sin, grads_exodus[k], atol=atol, rtol=rtol)
 
+
     # - Export parameters from exodus to sinabs
     new_sinabs_model = SinabsLIFModel(**model_kwargs).cuda()
-    new_sinabs_model(input_data)  # Enforce state initialization
+    new_sinabs_model(input_data[0])  # Enforce state initialization
     new_sinabs_model.load_state_dict(exodus_model.state_dict())
     # - Export parameters from sinabs to exodus
     new_exodus_model = ExodusLIFModel(**model_kwargs).cuda()
-    new_exodus_model(input_data)  # Enforce state initialization
+    new_exodus_model(input_data[0])  # Enforce state initialization
     new_exodus_model.load_state_dict(sinabs_model.state_dict())
     # - Evolve all four models
-    sinabs_out = sinabs_model(input_data)
-    exodus_out = exodus_model(input_data)
-    new_sinabs_out = new_sinabs_model(input_data)
-    new_exodus_out = new_exodus_model(input_data)
+    sinabs_out = sinabs_model(input_data[0])
+    exodus_out = exodus_model(input_data[0])
+    new_sinabs_out = new_sinabs_model(input_data[0])
+    new_exodus_out = new_exodus_model(input_data[0])
     for out in (exodus_out, new_sinabs_out, new_exodus_out):
         assert (out == sinabs_out).all()
 

--- a/tests/test_lif.py
+++ b/tests/test_lif.py
@@ -249,7 +249,7 @@ def test_exodus_sinabs_state_transfer(train_alphas, norm_input, train_time_const
 args = product((True, False), (True, False), (True, False))
 @pytest.mark.parametrize("train_alphas,norm_input,train_time_consts", args)
 def test_exodus_vs_sinabs_compare_grads(train_alphas, norm_input, train_time_consts):
-    n_epochs = 3
+    n_epochs = 1
     batch_size, time_steps = 10, 100
     n_input_channels, n_output_classes = 16, 10
     tau_mem = 20.0
@@ -325,19 +325,20 @@ def test_exodus_vs_sinabs_compare_grads(train_alphas, norm_input, train_time_con
         print(k, "max difference:", max_diff, "max rel. diff.:", max_rel_diff)
         assert torch.allclose(g_sin, grads_exodus[k], atol=atol, rtol=rtol)
 
+
     # - Export parameters from exodus to sinabs
     new_sinabs_model = SinabsLIFModel(**model_kwargs).cuda()
-    new_sinabs_model(input_data)  # Enforce state initialization
+    new_sinabs_model(input_data[0])  # Enforce state initialization
     new_sinabs_model.load_state_dict(exodus_model.state_dict())
     # - Export parameters from sinabs to exodus
     new_exodus_model = ExodusLIFModel(**model_kwargs).cuda()
-    new_exodus_model(input_data)  # Enforce state initialization
+    new_exodus_model(input_data[0])  # Enforce state initialization
     new_exodus_model.load_state_dict(sinabs_model.state_dict())
     # - Evolve all four models
-    sinabs_out = sinabs_model(input_data)
-    exodus_out = exodus_model(input_data)
-    new_sinabs_out = new_sinabs_model(input_data)
-    new_exodus_out = new_exodus_model(input_data)
+    sinabs_out = sinabs_model(input_data[0])
+    exodus_out = exodus_model(input_data[0])
+    new_sinabs_out = new_sinabs_model(input_data[0])
+    new_exodus_out = new_exodus_model(input_data[0])
     for out in (exodus_out, new_sinabs_out, new_exodus_out):
         assert (out == sinabs_out).all()
 

--- a/tests/test_lif.py
+++ b/tests/test_lif.py
@@ -249,6 +249,7 @@ def test_exodus_sinabs_state_transfer(train_alphas, norm_input, train_time_const
 args = product((True, False), (True, False), (True, False))
 @pytest.mark.parametrize("train_alphas,norm_input,train_time_consts", args)
 def test_exodus_vs_sinabs_compare_grads(train_alphas, norm_input, train_time_consts):
+    n_epochs = 3
     batch_size, time_steps = 10, 100
     n_input_channels, n_output_classes = 16, 10
     tau_mem = 20.0
@@ -277,12 +278,13 @@ def test_exodus_vs_sinabs_compare_grads(train_alphas, norm_input, train_time_con
         sinabs_layer.load_state_dict(exodus_layer.state_dict())
     assert (sinabs_model[0].weight == exodus_model[0].weight).all()
 
-    input_data = torch.rand((batch_size, time_steps, n_input_channels)).cuda()
+    input_data = torch.rand((n_epochs, batch_size, time_steps, n_input_channels)).cuda()
     if not norm_input:
         input_data *= 5e-2
 
     t_start = time.time()
-    sinabs_out = sinabs_model(input_data)
+    for inp_epoch in input_data:
+        sinabs_out = sinabs_model(inp_epoch)
     loss_sinabs = torch.nn.functional.mse_loss(sinabs_out, torch.ones_like(sinabs_out))
     loss_sinabs.backward()
     grads_sinabs = {
@@ -292,7 +294,8 @@ def test_exodus_vs_sinabs_compare_grads(train_alphas, norm_input, train_time_con
 
     exodus_model.zero_grad()
     t_start = time.time()
-    exodus_out = exodus_model(input_data)
+    for inp_epoch in input_data:
+        exodus_out = exodus_model(inp_epoch)
     loss_exodus = torch.nn.functional.mse_loss(exodus_out, torch.ones_like(exodus_out))
     loss_exodus.backward()
     grads_exodus = {

--- a/tests/test_spike_functions.py
+++ b/tests/test_spike_functions.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 from sinabs.exodus.spike import IntegrateAndFire
 from sinabs import activation as sa
+from sinabs.layers.functional.lif import lif_forward
 
 
 def test_integratefire():
@@ -49,3 +50,124 @@ def test_integratefire_backprop_vmem():
         # Gradients for membrane potential are not implemented
         v_mem.sum().backward()
 
+args = ("spikes", "vmem", "sum")
+@pytest.mark.parametrize("backward_var", args)
+def test_compare_integratefire_backward(backward_var):
+    time_steps = 100
+    n_neurons = 8
+    thr = 1
+    min_v_mem = -1
+    surrogate_gradient_fn = sa.Heaviside(0)
+    max_num_spikes_per_bin = 2
+    
+    # Input data and initialization 
+    input_sinabs = torch.rand((time_steps, n_neurons), requires_grad=True, device= "cuda")
+    v_mem_init_sinabs = torch.rand(n_neurons, requires_grad=True, device= "cuda")
+    alpha_sinabs = torch.rand(n_neurons, requires_grad=True, device= "cuda")
+
+    # Copy data without connecting gradients
+    input_exodus = input_sinabs.clone().detach().requires_grad_(True)
+    v_mem_init_exodus = v_mem_init_sinabs.clone().detach().requires_grad_(True)
+    alpha_sinabs.clone().detach().requires_grad_(True)
+
+    out_exodus, vmem_exodus = evolve_exodus(
+        inp=input_exodus,
+        alhpa=alpha_exodus,
+        v_mem_init=v_mem_init_exodus,
+        threshold=thr,
+        min_v_mem=min_v_mem,
+        surrogate_grad_fn=surrogate_gradient_fn,
+        max_num_spikes_per_bin=max_num_spikes_per_bin,
+    )
+
+    out_sinabs, vmem_sinabs = evolve_sinabs(
+        inp=input_sinabs,
+        alhpa=alpha_sinabs,
+        v_mem_init=v_mem_init_sinabs,
+        threshold=thr,
+        min_v_mem=min_v_mem,
+        surrogate_grad_fn=surrogate_gradient_fn,
+        max_num_spikes_per_bin=max_num_spikes_per_bin,
+    )
+
+    assert torch.allclose(out_exodus, out_sinabs)
+    assert torch.allclose(vmem_exodus, vmem_sinabs)
+
+    if backward_var == "spikes":
+        # random weights so the output grad tensor is less uniform
+        rand_weights = torch.rand_like(out_exodus)
+        # - Test backward pass through output spikes
+        (rand_weights * out_exodus).sum().backward()
+        (rand_weights * out_sinabs).sum().backward()
+    elif backward_var == "vmem":
+        # random weights so the output grad tensor is less uniform
+        rand_weights = torch.rand_like(vmem_exodus)
+        # - Test backward pass through membrane potential
+        (rand_weights * vmem_exodus).sum().backward()
+        (rand_weights * vmem_sinabs).sum().backward()
+    elif backward_var == "sum":        
+        # random weights so the output grad tensor is less uniform
+        w_out = torch.rand_like(out_exodus)
+        w_vmem = torch.rand_like(vmem_exodus)
+        # - Test backward pass through membrane potential
+        (out_exodus * w_out + vmem_exodus * w_vmem).sum().backward()
+        (out_sinabs * w_out + vmem_sinabs * w_vmem).sum().backward()
+
+    assert torch.allclose(input_sinabs.grad, input_exodus.grad)
+    assert torch.allclose(v_mem_init_sinabs.grad, v_mem_init_exodus.grad)
+    assert torch.allclose(alpha_sinabs.grad, alpha_exodus.grad)
+
+
+def evolve_exodus(
+    inp: torch.tensor,
+    alpha: torch.tensor,
+    v_mem_init: torch.tensor,
+    threshold: float,
+    min_v_mem: float,
+    surrogate_grad_fn: Callable,
+    max_num_spikes_per_bin: Optional[int] = None,
+):
+    output_spikes, v_mem = IntegrateAndFire.apply(
+        inp,
+        alpha,
+        v_mem_init,
+        threshold,
+        torch.ones_like(v_mem_init_exodus) * thr,  # membrane subtract
+        min_v_mem,
+        surrogate_grad_fn,
+        max_num_spikes_per_bin,
+    )
+
+    v_mem = v_mem - membrane_subtract.unsqueeze(1) * output_spikes
+
+    return output_spikes, v_mem
+
+def evolve_sinabs(
+    inp: torch.tensor,
+    alpha: torch.tensor,
+    v_mem_init: torch.tensor,
+    threshold: float,
+    min_v_mem: float,
+    surrogate_grad_fn: Callable,
+    max_num_spikes_per_bin: Optional[int] = None,
+):
+    if max_num_spikes_per_bin is not None:
+        spike_fn = sa.MaxSpike(max_num_spikes_per_bin)
+    else:
+        spike_fn = sa.MultiSpike
+
+    output_spikes, state, record_dict = lif_forward(
+        input_data=inp,
+        alpha_mem=alpha,
+        alpha_syn=None,
+        state={"v_mem": v_mem_init},
+        spike_threshold=threshold,
+        spike_fn=spike_fn,
+        reset_fn=sa.MembraneSubtract,
+        surrogate_grad_fn=surrogate_grad_fn,
+        min_v_mem=min_v_mem,
+        norm_input=False,
+        record_states=True
+    )
+
+    return output_spikes, record_dict["v_mem"]

--- a/tests/test_spike_functions.py
+++ b/tests/test_spike_functions.py
@@ -46,24 +46,34 @@ def test_integratefire_backprop_vmem():
         surrogate_gradient_fn,
     )
 
-    with pytest.raises(NotImplementedError):
-        # Gradients for membrane potential are not implemented
-        v_mem.sum().backward()
 
 args = ("spikes", "vmem", "sum")
+
+
 @pytest.mark.parametrize("backward_var", args)
-def test_compare_integratefire_backward(backward_var):
+def test_compare_integratefire(backward_var):
+
+    torch.manual_seed(1)
+
     time_steps = 100
+    batchsize = 10
     n_neurons = 8
+    num_epochs = 3
     thr = 1
-    min_v_mem = -1
-    surrogate_gradient_fn = sa.Heaviside(0)
+    min_v_mem = None  # -1
+    surrogate_grad_fn = sa.PeriodicExponential()
     max_num_spikes_per_bin = 2
-    
-    # Input data and initialization 
-    input_sinabs = torch.rand((time_steps, n_neurons), requires_grad=True, device= "cuda")
-    v_mem_init_sinabs = torch.rand(n_neurons, requires_grad=True, device= "cuda")
-    alpha_sinabs = torch.rand(n_neurons, requires_grad=True, device= "cuda")
+
+    # Input data and initialization
+    input_sinabs = torch.rand(
+        (num_epochs, batchsize, time_steps, n_neurons),
+        requires_grad=True,
+        device="cuda",
+    )
+    v_mem_init_sinabs = torch.rand(
+        batchsize, n_neurons, requires_grad=True, device="cuda"
+    )
+    alpha_sinabs = torch.rand(n_neurons, requires_grad=True, device="cuda")
 
     # Copy data without connecting gradients
     input_exodus = input_sinabs.clone().detach().requires_grad_(True)
@@ -71,27 +81,27 @@ def test_compare_integratefire_backward(backward_var):
     alpha_exodus = alpha_sinabs.clone().detach().requires_grad_(True)
 
     out_exodus, vmem_exodus = evolve_exodus(
-        inp=input_exodus,
+        data=input_exodus,
         alpha=alpha_exodus,
         v_mem_init=v_mem_init_exodus,
         threshold=thr,
         min_v_mem=min_v_mem,
-        surrogate_grad_fn=surrogate_gradient_fn,
+        surrogate_grad_fn=surrogate_grad_fn,
         max_num_spikes_per_bin=max_num_spikes_per_bin,
     )
 
     out_sinabs, vmem_sinabs = evolve_sinabs(
-        inp=input_sinabs,
+        data=input_sinabs,
         alpha=alpha_sinabs,
         v_mem_init=v_mem_init_sinabs,
         threshold=thr,
         min_v_mem=min_v_mem,
-        surrogate_grad_fn=surrogate_gradient_fn,
+        surrogate_grad_fn=surrogate_grad_fn,
         max_num_spikes_per_bin=max_num_spikes_per_bin,
     )
 
     assert torch.allclose(out_exodus, out_sinabs)
-    assert torch.allclose(vmem_exodus, vmem_sinabs)
+    assert torch.allclose(vmem_exodus, vmem_sinabs, rtol=1e-4, atol=1e-8)
 
     if backward_var == "spikes":
         # random weights so the output grad tensor is less uniform
@@ -105,70 +115,88 @@ def test_compare_integratefire_backward(backward_var):
         # - Test backward pass through membrane potential
         (rand_weights * vmem_exodus).sum().backward()
         (rand_weights * vmem_sinabs).sum().backward()
-    elif backward_var == "sum":        
+    elif backward_var == "sum":
         # random weights so the output grad tensor is less uniform
         w_out = torch.rand_like(out_exodus)
         w_vmem = torch.rand_like(vmem_exodus)
         # - Test backward pass through membrane potential
-        (out_exodus * w_out + vmem_exodus * w_vmem).sum().backward()
-        (out_sinabs * w_out + vmem_sinabs * w_vmem).sum().backward()
+        (out_exodus * w_out + (vmem_exodus * w_vmem).unsqueeze(1)).sum().backward()
+        (out_sinabs * w_out + (vmem_sinabs * w_vmem).unsqueeze(1)).sum().backward()
 
-    assert torch.allclose(input_sinabs.grad, input_exodus.grad)
-    assert torch.allclose(v_mem_init_sinabs.grad, v_mem_init_exodus.grad)
-    assert torch.allclose(alpha_sinabs.grad, alpha_exodus.grad)
+    assert torch.allclose(input_sinabs.grad, input_exodus.grad, rtol=1e-4, atol=1e-6)
+    assert torch.allclose(v_mem_init_sinabs.grad, v_mem_init_exodus.grad, rtol=1e-4, atol=1e-6)
+    assert torch.allclose(alpha_sinabs.grad, alpha_exodus.grad, rtol=1e-4, atol=1e-6)
 
 
 def evolve_exodus(
-    inp: torch.tensor,
+    data: torch.tensor,
     alpha: torch.tensor,
     v_mem_init: torch.tensor,
     threshold: float,
     min_v_mem: float,
     surrogate_grad_fn,
-    max_num_spikes_per_bin = None,
+    max_num_spikes_per_bin=None,
 ):
-    membrane_subtract = torch.ones_like(v_mem_init) * threshold
-    output_spikes, v_mem = IntegrateAndFire.apply(
-        inp,
-        alpha,
-        v_mem_init,
-        threshold,
-        membrane_subtract,
-        min_v_mem,
-        surrogate_grad_fn,
-        max_num_spikes_per_bin,
+    alpha = alpha.expand(v_mem_init.shape).flatten().contiguous()
+    v_mem_init = v_mem_init.flatten().contiguous()
+    membrane_subtract = torch.full_like(alpha, threshold)
+    batchsize, timesteps, *trailing_dim = data.shape[1:]
+
+    for inp in data:
+        inp = inp.movedim(1, -1).reshape(-1, timesteps)
+        output_spikes, v_mem = IntegrateAndFire.apply(
+            inp.contiguous(),
+            alpha,
+            v_mem_init,
+            threshold,
+            membrane_subtract,
+            min_v_mem,
+            surrogate_grad_fn,
+            max_num_spikes_per_bin,
+        )
+
+        v_mem = v_mem - membrane_subtract.unsqueeze(1) * output_spikes
+        v_mem_init = v_mem[:, -1].contiguous()
+
+    return (
+        output_spikes.reshape(batchsize, *trailing_dim, timesteps).movedim(-1, 1),
+        v_mem[:, -1].reshape(batchsize, *trailing_dim),
     )
 
-    v_mem = v_mem - membrane_subtract.unsqueeze(0) * output_spikes
-
-    return output_spikes, v_mem
 
 def evolve_sinabs(
-    inp: torch.tensor,
+    data: torch.tensor,
     alpha: torch.tensor,
     v_mem_init: torch.tensor,
     threshold: float,
     min_v_mem: float,
-    surrogate_grad_fn, 
-    max_num_spikes_per_bin = None,
+    surrogate_grad_fn,
+    max_num_spikes_per_bin=None,
 ):
     if max_num_spikes_per_bin is not None:
         spike_fn = sa.MaxSpike(max_num_spikes_per_bin)
     else:
         spike_fn = sa.MultiSpike
 
-    output_spikes, state, record_dict = lif_forward(
-        input_data=inp.unsqueeze(0), # Add batch dimension
-        alpha_mem=alpha,
-        alpha_syn=None,
-        state={"v_mem": v_mem_init},
-        spike_threshold=threshold,
-        spike_fn=spike_fn,
-        reset_fn=sa.MembraneSubtract(),
-        surrogate_grad_fn=surrogate_grad_fn,
-        min_v_mem=min_v_mem,
-        norm_input=False,
-        record_states=True
-    )
+    state = {"v_mem": v_mem_init}
 
-    return output_spikes, record_dict["v_mem"]
+    for inp in data:
+        # Add batch dimension and move time to dimension 1
+
+        output_spikes, state, record_dict = lif_forward(
+            input_data=inp,
+            alpha_mem=alpha,
+            alpha_syn=None,
+            state=state,
+            spike_threshold=threshold,
+            spike_fn=spike_fn,
+            reset_fn=sa.MembraneSubtract(),
+            surrogate_grad_fn=surrogate_grad_fn,
+            min_v_mem=min_v_mem,
+            norm_input=False,
+            record_states=True,
+        )
+
+    # Squeeze batch dimensions and move time to last
+    # return output_spikes.squeeze(0).movedim(-1,0), record_dict["v_mem"].squeeze(0).movedim(-1, 0)[:, -1]
+    return output_spikes, state["v_mem"]


### PR DESCRIPTION
This PR lets EXODUS backpropagate through vmem, which is necessary to calculate gradients correctly if the backward pass is done after multiple forward passes.

It also fixes a small inaccuracy in the gradient of the `LeakyIntegrator` with respect to `alpha`.

Unit tests are extended accordingly.